### PR TITLE
Update mobile search UI

### DIFF
--- a/src/layout/PrimaryHeaderMenu.tsx
+++ b/src/layout/PrimaryHeaderMenu.tsx
@@ -1,24 +1,17 @@
 import {
-  ActionIcon,
   Box,
   Burger,
-  Drawer,
   Flex,
   getGradient,
   Group,
-  Indicator,
-  Text,
   UnstyledButton,
   useMantineTheme,
 } from "@mantine/core"
-import { NavLink, useSearchParams } from "react-router-dom"
+import { NavLink } from "react-router-dom"
 import classes from "./MainLayout.module.css"
 import { AppRoute } from "../App"
 import LexoTermLogo from "./LexoTermLogo"
 import classNames from "classnames"
-import { IconFilter2Search } from "@tabler/icons-react"
-import { useDisclosure } from "@mantine/hooks"
-import ComplexSearchForm from "../ui/ComplexSearchForm"
 import { HEADER_HEIGHT, MENU_BREAKPOINT } from "./MainLayout"
 
 export default function PrimaryHeaderMenu({
@@ -30,10 +23,6 @@ export default function PrimaryHeaderMenu({
   opened: boolean
   toggle: () => void
 }) {
-  const [filtersOpened, { open: openFilters, close: closeFilters }] =
-    useDisclosure(false)
-
-  const [searchParams] = useSearchParams()
   const theme = useMantineTheme()
 
   return (
@@ -55,6 +44,7 @@ export default function PrimaryHeaderMenu({
         maw={"1440px"}
         mx="auto"
       >
+        <LexoTermLogo />
         <Burger
           opened={opened}
           onClick={toggle}
@@ -62,7 +52,6 @@ export default function PrimaryHeaderMenu({
           size="md"
           color="white"
         />
-        <LexoTermLogo />
         <Group ml="xl" gap={0} visibleFrom={MENU_BREAKPOINT}>
           {routes.map(({ path, title }) => (
             <UnstyledButton
@@ -88,35 +77,6 @@ export default function PrimaryHeaderMenu({
             </UnstyledButton>
           ))}
         </Group>
-        <ActionIcon
-          style={{ color: "inherit" }}
-          hiddenFrom={MENU_BREAKPOINT}
-          size="lg"
-          variant="subtle"
-          aria-label="Settings"
-          onClick={openFilters}
-        >
-          <Indicator offset={5} disabled={searchParams.size === 0} size={6}>
-            <IconFilter2Search stroke={1.5} />
-          </Indicator>
-        </ActionIcon>
-        <Drawer
-          offset={8}
-          title={
-            <Text size="xl" fw="bold">
-              Suchfilter
-            </Text>
-          }
-          radius="md"
-          size="lg"
-          padding="lg"
-          opened={filtersOpened}
-          position={"top"}
-          overlayProps={{ backgroundOpacity: 0.5, blur: 4 }}
-          onClose={closeFilters}
-        >
-          <ComplexSearchForm onSubmit={closeFilters} />
-        </Drawer>
       </Flex>
     </Box>
   )

--- a/src/pages/SearchView.tsx
+++ b/src/pages/SearchView.tsx
@@ -27,6 +27,30 @@ export default function SearchView() {
     useDisclosure(false)
   const [searchParams] = useSearchParams()
   const theme = useMantineTheme()
+
+  const leftColumn = (
+    <>
+      <ContentPanel title="Suche">
+        <ComplexSearchForm />
+      </ContentPanel>
+      <ContentPanel title="Stichwortsuche">
+        <KeywordList />
+      </ContentPanel>
+    </>
+  )
+
+  return (
+    <Grid p={"md"} pt={"md"} mx={"auto"} gutter="xs">
+      {
+        <Grid.Col span={{ base: 12, sm: 4 }}>
+          <Stack gap={"xs"}>
+            <Box visibleFrom={MENU_BREAKPOINT}>{leftColumn}</Box>
+            <Box hiddenFrom={MENU_BREAKPOINT}>
+              {searchParams.size === 0 && leftColumn}
+            </Box>
+          </Stack>
+        </Grid.Col>
+      }
       <Grid.Col span={{ base: 12, sm: 4 }}>
         <ResultSummary
           activeLemmaId={activeLemmaId}

--- a/src/pages/SearchView.tsx
+++ b/src/pages/SearchView.tsx
@@ -1,26 +1,32 @@
-import { Grid, Stack } from "@mantine/core"
+import {
+  ActionIcon,
+  Affix,
+  Text,
+  Drawer,
+  Grid,
+  Stack,
+  Indicator,
+  alpha,
+  useMantineTheme,
+  Box,
+} from "@mantine/core"
 import ComplexSearchForm from "../ui/ComplexSearchForm"
 import ContentPanel from "../ui/ContentPanel"
 import ResultSummary from "../ui/ResultSummary"
 import LemmaDetail from "../ui/LemmaDetail"
 import { useState } from "react"
 import KeywordList from "../ui/KeywordList"
+import { MENU_BREAKPOINT } from "../layout/MainLayout"
+import { useDisclosure } from "@mantine/hooks"
+import { IconFilter2Search } from "@tabler/icons-react"
+import { useSearchParams } from "react-router-dom"
 
 export default function SearchView() {
   const [activeLemmaId, setActiveLemmaId] = useState<string | null>(null)
-
-  return (
-    <Grid p={"md"} pt={"md"} mx={"auto"} gutter="xs">
-      <Grid.Col visibleFrom="sm" span={{ base: 12, sm: 4 }}>
-        <Stack gap={"xs"}>
-          <ContentPanel title="Suche">
-            <ComplexSearchForm />
-          </ContentPanel>
-          <ContentPanel title="Stichwortsuche">
-            <KeywordList />
-          </ContentPanel>
-        </Stack>
-      </Grid.Col>
+  const [filtersOpened, { open: openFilters, close: closeFilters }] =
+    useDisclosure(false)
+  const [searchParams] = useSearchParams()
+  const theme = useMantineTheme()
       <Grid.Col span={{ base: 12, sm: 4 }}>
         <ResultSummary
           activeLemmaId={activeLemmaId}
@@ -34,6 +40,50 @@ export default function SearchView() {
           </ContentPanel>
         )}
       </Grid.Col>
+      {searchParams.size !== 0 && (
+        <Affix position={{ bottom: 50, right: 50 }}>
+          <ActionIcon
+            hiddenFrom={MENU_BREAKPOINT}
+            size="lg"
+            variant={"gradient"}
+            gradient={{
+              deg: 90,
+              from: "lexoterm-primary",
+              to: alpha(theme.colors["lexoterm-primary"][0], 0.75),
+            }}
+            radius={"xl"}
+            p={"lg"}
+            aria-label="Settings"
+            onClick={openFilters}
+          >
+            <Indicator
+              offset={5}
+              disabled={searchParams.size === 0}
+              size={8}
+              color={"lexoterm-secondary.0"}
+            >
+              <IconFilter2Search stroke={1.5} />
+            </Indicator>
+          </ActionIcon>
+        </Affix>
+      )}
+      <Drawer
+        offset={8}
+        title={
+          <Text size="xl" fw="bold">
+            Suchfilter
+          </Text>
+        }
+        radius="md"
+        size="lg"
+        padding="lg"
+        opened={filtersOpened}
+        position={"top"}
+        overlayProps={{ backgroundOpacity: 0.5, blur: 4 }}
+        onClose={closeFilters}
+      >
+        <ComplexSearchForm onSubmit={closeFilters} />
+      </Drawer>
     </Grid>
   )
 }

--- a/src/pages/SearchView.tsx
+++ b/src/pages/SearchView.tsx
@@ -99,7 +99,7 @@ export default function SearchView() {
           </Text>
         }
         radius="md"
-        size="lg"
+        size="xl"
         padding="lg"
         opened={filtersOpened}
         position={"top"}

--- a/src/pages/SearchView.tsx
+++ b/src/pages/SearchView.tsx
@@ -65,9 +65,11 @@ export default function SearchView() {
         )}
       </Grid.Col>
       {searchParams.size !== 0 && (
-        <Affix position={{ bottom: 50, right: 50 }}>
+        <Affix
+          position={{ bottom: 50, right: 50 }}
+          hiddenFrom={MENU_BREAKPOINT}
+        >
           <ActionIcon
-            hiddenFrom={MENU_BREAKPOINT}
             size="lg"
             variant={"gradient"}
             gradient={{

--- a/src/pages/SearchView.tsx
+++ b/src/pages/SearchView.tsx
@@ -23,7 +23,7 @@ import { useSearchParams } from "react-router-dom"
 
 export default function SearchView() {
   const [activeLemmaId, setActiveLemmaId] = useState<string | null>(null)
-  const [filtersOpened, { open: openFilters, close: closeFilters }] =
+  const [filtersOpened, { toggle: toggleFilters, close: closeFilters }] =
     useDisclosure(false)
   const [searchParams] = useSearchParams()
   const theme = useMantineTheme()
@@ -80,7 +80,7 @@ export default function SearchView() {
             radius={"xl"}
             p={"lg"}
             aria-label="Settings"
-            onClick={openFilters}
+            onClick={toggleFilters}
           >
             <Indicator
               offset={5}


### PR DESCRIPTION
The search page shows blank on mobile due to the search column being hidden. The top menu has a button to open the search filters as modal, but

1. that is not obvious
2. the button is shown site-wide.

Solution:

- Update the mobile top menu
    - Remove the search filter button
    - Move the LexoTerm logo to the left and the hamburger main navigation to the right
- Update the mobile search view
    - Show the search filters and keyword panel when no search parameters are set (including the first visit)
    - Add a floating button (affix) to open filters when search parameters are set